### PR TITLE
Added session variable to keep track of failed CC attempts before a Success

### DIFF
--- a/src/app/code/community/EbayEnterprise/CreditCard/Model/Method/Ccpayment.php
+++ b/src/app/code/community/EbayEnterprise/CreditCard/Model/Method/Ccpayment.php
@@ -365,6 +365,7 @@ class EbayEnterprise_CreditCard_Model_Method_Ccpayment extends Mage_Payment_Mode
     {
         // if auth was a complete success, accept the response and move on
         if ($response->getIsAuthSuccessful()) {
+	    Mage::getSingleton('core/session')->setFailedCCAttempts(0);
             return $this;
         }
         // if AVS correction is needed, redirect to billing address step
@@ -379,6 +380,7 @@ class EbayEnterprise_CreditCard_Model_Method_Ccpayment extends Mage_Payment_Mode
         // request is at least acceptable - timeout perhaps - and if so, take it
         // and allow order submit to continue
         if ($response->getIsAuthAcceptable()) {
+	    Mage::getSingleton('core/session')->setFailedCCAttempts(0);
             return $this;
         }
         // auth failed for some other reason, possibly declined, making it unacceptable
@@ -470,6 +472,16 @@ class EbayEnterprise_CreditCard_Model_Method_Ccpayment extends Mage_Payment_Mode
      */
     protected function _failPaymentRequest($errorMessage, $returnStep = 'payment')
     {
+	$prev = Mage::getSingleton('core/session')->getFailedCCAttempts();
+
+        if(!$prev)
+        {
+                Mage::getSingleton('core/session')->setFailedCCAttempts(1);
+        } else {
+                $prev++;
+                Mage::getSingleton('core/session')->setFailedCCAttempts($prev);
+        }
+
         $this->_setCheckoutStep($returnStep);
         throw Mage::exception('EbayEnterprise_CreditCard', $this->_helper->__($errorMessage));
     }


### PR DESCRIPTION
Added session variable to keep track of failed CC attempts before a Success ...

For optional RiskAssessmentRequest attribute FailedCc Number:

https://gitlab.gspt.net/Cheetah/retailordermanagement-sdk/blob/master/src/eBayEnterprise/RetailOrderManagement/Schemas/checkout/1.0/Risk-Service-Datatypes-1.0.xsd

<xsd:element name="FailedCc" type="FailedCcType" minOccurs="0"/>

<xsd:complexType name="FailedCcType">
    <xsd:attribute name="Number" type="xsd:int" use="required">
      xsd:annotation
        <xsd:documentation xml:lang="en">
                Definition: The number of failed credit card authorizations.
                Sample Data: 3
                /xsd:documentation
      /xsd:annotation
    /xsd:attribute
  /xsd:complexType
