### PR TITLE
Ensure that after an invoice is processed and marked as Paid, the invoice->pay() call is executed

### DIFF
--- a/src/app/code/community/Radial/CreditCard/Model/Method/Ccpayment.php
+++ b/src/app/code/community/Radial/CreditCard/Model/Method/Ccpayment.php
@@ -870,6 +870,7 @@ class Radial_CreditCard_Model_Method_Ccpayment extends Mage_Payment_Model_Method
     protected function _handleDebitResponse(Api\IBidirectionalApi $api, Mage_Sales_Model_Order_Invoice $invoice)
     {
         $invoice->setState(Mage_Sales_Model_Order_Invoice::STATE_PAID);
+	$invoice->pay();
         return $this;
     }
     /**

--- a/src/app/code/community/Radial/PayPal/Model/Express/Api.php
+++ b/src/app/code/community/Radial/PayPal/Model/Express/Api.php
@@ -227,6 +227,7 @@ class Radial_Paypal_Model_Express_Api
     protected function _handleCaptureResponse(Api\IBidirectionalApi $sdk, Mage_Sales_Model_Order_Invoice $invoice)
     {
         $invoice->setState(Mage_Sales_Model_Order_Invoice::STATE_PAID);
+	$invoice->pay();
         return $this;
     }
     /**

--- a/src/app/code/community/Radial/PayPal/Model/Method/Express.php
+++ b/src/app/code/community/Radial/PayPal/Model/Method/Express.php
@@ -182,6 +182,12 @@ class Radial_PayPal_Model_Method_Express extends Mage_Payment_Model_Method_Abstr
             // settlement must be allowed to fail
             // set creditmemo status as OPEN to trigger a retry and notify admin
             $creditmemo->setState(Mage_Sales_Model_Order_Creditmemo::STATE_OPEN);
+
+	    $retry = $creditmemo->getDeliveryStatus();
+            $retryN = $retry + 1;
+            $creditmemo->setDeliveryStatus($retryN);
+            $creditmemo->save();
+
             $errorMessage = $this->_helper->__(self::SETTLEMENT_FAILED_MESSAGE);
             $this->getSession()->addNotice($errorMessage);
             $this->_logger->logException($e, $this->_context->getMetaData(__CLASS__, [], $e));
@@ -207,6 +213,12 @@ class Radial_PayPal_Model_Method_Express extends Mage_Payment_Model_Method_Abstr
             // settlement must be allowed to fail
             // set invoice status as OPEN to trigger a  retry and notify admin
             $invoice->setIsPaid(false);
+
+	    $retry = $invoice->getDeliveryStatus();
+            $retryN = $retry + 1;
+            $invoice->setDeliveryStatus($retryN);
+            $invoice->save();
+
             $errorMessage = $this->_helper->__(self::SETTLEMENT_FAILED_MESSAGE);
             $this->getSession()->addNotice($errorMessage);
             $this->_logger->logException($e, $this->_context->getMetaData(__CLASS__, [], $e));


### PR DESCRIPTION
Ensure that after an invoice is processed and marked as Paid, the invoice->pay() call is executed

Ensure that the retry count is kept for paypal initiated orders. 
