### PR TITLE
MPTF-164 use magento tax in case radial_tax isnt installed

### DIFF
--- a/src/app/code/community/Radial/PayPal/Model/Express/Api.php
+++ b/src/app/code/community/Radial/PayPal/Model/Express/Api.php
@@ -746,8 +746,15 @@ class Radial_Paypal_Model_Express_Api
                 ->processNegativeLineItems($quote, $container->getLineItems());
             $container->calculateLineItemsTotal();
             $container->setShippingTotal($this->getTotal('shipping', $quote));
-            $container->setTaxTotal($this->getTotal('radial_tax', $quote));
-            $container->setCurrencyCode($quote->getQuoteCurrencyCode());
+            
+	    if( Mage::helper('core')->isModuleEnabled('radial_tax'))
+            {
+                $container->setTaxTotal($this->getTotal('radial_tax', $quote));
+            } else {
+                $container->setTaxTotal(Mage::helper('checkout')->getQuote()->getShippingAddress()->getData('tax_amount'));
+            }
+
+	    $container->setCurrencyCode($quote->getQuoteCurrencyCode());
         }
     }
 

--- a/src/app/code/community/Radial/PayPal/Model/Express/Api.php
+++ b/src/app/code/community/Radial/PayPal/Model/Express/Api.php
@@ -747,11 +747,11 @@ class Radial_Paypal_Model_Express_Api
             $container->calculateLineItemsTotal();
             $container->setShippingTotal($this->getTotal('shipping', $quote));
             
-	    if( isset($quote->getData()['radial_tax']))
+	    if( isset($quote->getTotals()['radial_tax']) && $quote->getTotals()['radial_tax']->getValue())
             {
                 $container->setTaxTotal($this->getTotal('radial_tax', $quote));
             } else {
-                $container->setTaxTotal(Mage::helper('checkout')->getQuote()->getShippingAddress()->getData('tax_amount'));
+                $container->setTaxTotal($quote->getTotals()['tax']->getValue());
             }
 
 	    $container->setCurrencyCode($quote->getQuoteCurrencyCode());

--- a/src/app/code/community/Radial/PayPal/Model/Express/Api.php
+++ b/src/app/code/community/Radial/PayPal/Model/Express/Api.php
@@ -747,7 +747,7 @@ class Radial_Paypal_Model_Express_Api
             $container->calculateLineItemsTotal();
             $container->setShippingTotal($this->getTotal('shipping', $quote));
             
-	    if( Mage::helper('core')->isModuleEnabled('radial_tax'))
+	    if( isset($quote->getData()['radial_tax']))
             {
                 $container->setTaxTotal($this->getTotal('radial_tax', $quote));
             } else {

--- a/src/app/code/community/Radial/PayPal/Test/Model/Express/ApiTest.php
+++ b/src/app/code/community/Radial/PayPal/Test/Model/Express/ApiTest.php
@@ -189,7 +189,7 @@ class Radial_PayPal_Test_Model_Express_ApiTest extends Radial_Core_Test_Base
                             [
                                 'grand_total' => new Varien_Object(['value' => 100]),
                                 'shipping' => new Varien_Object(['value' => 5.95]),
-                                'tax' => new Varien_Object(['value' => 2.50]),
+                                'tax_amount' => new Varien_Object(['value' => 2.50]),
                                 'discount' => new Varien_Object(['value' => 100]),
                             ]   
                 )       

--- a/src/app/code/community/Radial/PayPal/Test/Model/Express/ApiTest.php
+++ b/src/app/code/community/Radial/PayPal/Test/Model/Express/ApiTest.php
@@ -175,7 +175,7 @@ class Radial_PayPal_Test_Model_Express_ApiTest extends Radial_Core_Test_Base
                         'grand_total' => new Varien_Object(['value' => 100]),
                         'shipping' => new Varien_Object(['value' => 5.95]),
                         'radial_tax' => new Varien_Object(['value' => 2.50]),
-			'tax_amount' => new Varien_Object(['value' => 2.50]),
+			'tax' => new Varien_Object(['value' => 2.50]),
                         'discount' => new Varien_Object(['value' => 100]),
                     ]
                 )

--- a/src/app/code/community/Radial/PayPal/Test/Model/Express/ApiTest.php
+++ b/src/app/code/community/Radial/PayPal/Test/Model/Express/ApiTest.php
@@ -169,32 +169,17 @@ class Radial_PayPal_Test_Model_Express_ApiTest extends Radial_Core_Test_Base
         $this->quote->expects($this->any())
             ->method('reserveOrderId')->will($this->returnSelf());
 
-	if( Mage::helper('core')->isModuleEnabled('radial_tax'))
-	{
-	    $this->quote->expects($this->any())
-        	    ->method('getTotals')->will(
-        	        $this->returnValue(
-        	            [
-        	                'grand_total' => new Varien_Object(['value' => 100]),
-        	                'shipping' => new Varien_Object(['value' => 5.95]),
-        	                'radial_tax' => new Varien_Object(['value' => 2.50]),
-                        	'discount' => new Varien_Object(['value' => 100]),
-                    	    ]
+	$this->quote->expects($this->any())
+            ->method('getTotals')->will(
+                $this->returnValue(
+                    [
+                        'grand_total' => new Varien_Object(['value' => 100]),
+                        'shipping' => new Varien_Object(['value' => 5.95]),
+                        'radial_tax' => new Varien_Object(['value' => 2.50]),
+                       	'discount' => new Varien_Object(['value' => 100]),
+                    ]
                 )
-            );
-	} else {
-	    $this->quote->expects($this->any())
-                    ->method('getTotals')->will(
-                        $this->returnValue(
-                            [
-                                'grand_total' => new Varien_Object(['value' => 100]),
-                                'shipping' => new Varien_Object(['value' => 5.95]),
-                                'tax_amount' => new Varien_Object(['value' => 2.50]),
-                                'discount' => new Varien_Object(['value' => 100]),
-                            ]   
-                )       
-            );
-	}
+        );
 
         $this->quote->expects($this->any())
             ->method('getReservedOrderId')->will($this->returnValue('orderid'));

--- a/src/app/code/community/Radial/PayPal/Test/Model/Express/ApiTest.php
+++ b/src/app/code/community/Radial/PayPal/Test/Model/Express/ApiTest.php
@@ -180,6 +180,34 @@ class Radial_PayPal_Test_Model_Express_ApiTest extends Radial_Core_Test_Base
                     ]
                 )
             );
+
+	if( Mage::helper('core')->isModuleEnabled('radial_tax'))
+	{
+	    $this->quote->expects($this->any())
+        	    ->method('getTotals')->will(
+        	        $this->returnValue(
+        	            [
+        	                'grand_total' => new Varien_Object(['value' => 100]),
+        	                'shipping' => new Varien_Object(['value' => 5.95]),
+        	                'radial_tax' => new Varien_Object(['value' => 2.50]),
+                        	'discount' => new Varien_Object(['value' => 100]),
+                    	    ]
+                )
+            );
+	} else {
+	    $this->quote->expects($this->any())
+                    ->method('getTotals')->will(
+                        $this->returnValue(
+                            [
+                                'grand_total' => new Varien_Object(['value' => 100]),
+                                'shipping' => new Varien_Object(['value' => 5.95]),
+                                'tax' => new Varien_Object(['value' => 2.50]),
+                                'discount' => new Varien_Object(['value' => 100]),
+                            ]   
+                )       
+            );
+	}
+
         $this->quote->expects($this->any())
             ->method('getReservedOrderId')->will($this->returnValue('orderid'));
         $this->quote->expects($this->any())

--- a/src/app/code/community/Radial/PayPal/Test/Model/Express/ApiTest.php
+++ b/src/app/code/community/Radial/PayPal/Test/Model/Express/ApiTest.php
@@ -175,6 +175,7 @@ class Radial_PayPal_Test_Model_Express_ApiTest extends Radial_Core_Test_Base
                         'grand_total' => new Varien_Object(['value' => 100]),
                         'shipping' => new Varien_Object(['value' => 5.95]),
                         'radial_tax' => new Varien_Object(['value' => 2.50]),
+			'tax_amount' => new Varien_Object(['value' => 2.50]),
                         'discount' => new Varien_Object(['value' => 100]),
                     ]
                 )

--- a/src/app/code/community/Radial/PayPal/Test/Model/Express/ApiTest.php
+++ b/src/app/code/community/Radial/PayPal/Test/Model/Express/ApiTest.php
@@ -168,18 +168,6 @@ class Radial_PayPal_Test_Model_Express_ApiTest extends Radial_Core_Test_Base
         );
         $this->quote->expects($this->any())
             ->method('reserveOrderId')->will($this->returnSelf());
-        $this->quote->expects($this->any())
-            ->method('getTotals')->will(
-                $this->returnValue(
-                    [
-                        'grand_total' => new Varien_Object(['value' => 100]),
-                        'shipping' => new Varien_Object(['value' => 5.95]),
-                        'radial_tax' => new Varien_Object(['value' => 2.50]),
-			'tax' => new Varien_Object(['value' => 2.50]),
-                        'discount' => new Varien_Object(['value' => 100]),
-                    ]
-                )
-            );
 
 	if( Mage::helper('core')->isModuleEnabled('radial_tax'))
 	{


### PR DESCRIPTION
MPTF-164 - use magento tax in case radial_tax isnt installed
